### PR TITLE
Add books grouped by category headings

### DIFF
--- a/content/books.md
+++ b/content/books.md
@@ -9,48 +9,67 @@ This page tracks books I have finished and books that I would like to read somed
 
 ## Finished
 
+### Self-help
 - [Tribe of Mentors](https://en.wikipedia.org/wiki/Tribe_of_Mentors) by Tim Ferriss
 - [The Systems Mindset](https://en.wikipedia.org/wiki/Sam_Carpenter) by Sam Carpenter
 - [A More Beautiful Question](https://en.wikipedia.org/wiki/Warren_Berger) by Warren Berger
-- [Program or Be Programmed: Ten Commands for a Digital Age](https://en.wikipedia.org/wiki/Douglas_Rushkoff#Books) by Douglas Rushkoff
-- [What the Dog Saw](https://en.wikipedia.org/wiki/Malcolm_Gladwell) by Malcolm Gladwell
-- [Man's Search for Meaning](https://en.wikipedia.org/wiki/Man%27s_Search_for_Meaning) by Viktor Frankl
-- [Fooled by Randomness](https://en.wikipedia.org/wiki/Nassim_Nicholas_Taleb#Bibliography) by Nassim Nicholas Taleb
 - [Atomic Habits](https://en.wikipedia.org/wiki/James_Clear) by James Clear
-- [Discover Your Inner Economist](https://en.wikipedia.org/wiki/Tyler_Cowen#Bibliography) by Tyler Cowen
-- [Your Memory](https://en.wikipedia.org/wiki/Kenneth_L._Higbee) by Kenneth L. Higbee
-- [Zero to One: Notes on Startups, or How to Build the Future](https://en.wikipedia.org/wiki/Zero_to_One) by Peter Thiel and Blake Masters
-- [Meditations](https://en.wikipedia.org/wiki/Meditations) by Marcus Aurelius
-- [Brave New World](https://en.wikipedia.org/wiki/Brave_New_World) by Aldous Huxley
-- [What I Talk About When I Talk About Running](https://en.wikipedia.org/wiki/What_I_Talk_About_When_I_Talk_About_Running) by Haruki Murakami
-- [Napoleon: A Life](https://en.wikipedia.org/wiki/Andrew_Roberts_(historian)) by Andrew Roberts
 - [Way of the Warrior Kid: From Wimpy to Warrior the Navy SEAL Way](https://en.wikipedia.org/wiki/Jocko_Willink) by Jocko Willink
 - [Make It Stick](https://en.wikipedia.org/wiki/Make_It_Stick) by Peter C. Brown, Henry L. Roediger III, and Mark A. McDaniel
-- [The Four Filters Invention of Warren Buffett and Charlie Munger](https://en.wikipedia.org/wiki/Warren_Buffett) by Bud Labitan
 - [The Think Big Manifesto](https://en.wikipedia.org/wiki/Michael_Port) by Michael Port
-- [The Sense of Style](https://en.wikipedia.org/wiki/The_Sense_of_Style) by Steven Pinker
-- [Writing Tools](https://en.wikipedia.org/wiki/Roy_Peter_Clark) by Roy Peter Clark
-- [Bird by Bird: Some Instructions on Writing and Life](https://en.wikipedia.org/wiki/Bird_by_Bird) by Anne Lamott
-- [Zone to Win](https://en.wikipedia.org/wiki/Geoffrey_Moore) by Geoffrey A. Moore
-- [Homo Deus](https://en.wikipedia.org/wiki/Homo_Deus:_A_Brief_History_of_Tomorrow) by Yuval Noah Harari
 - [The Power of No](https://en.wikipedia.org/wiki/James_Altucher#Books) by James Altucher and Claudia Azula Altucher
 - [The Subtle Art of Not Giving a F*ck](https://en.wikipedia.org/wiki/The_Subtle_Art_of_Not_Giving_a_F*ck) by Mark Manson
-- [Surely You're Joking, Mr. Feynman!](https://en.wikipedia.org/wiki/Surely_You%27re_Joking,_Mr._Feynman!) by Richard Feynman and Ralph Leighton
 - [The Organized Mind: Thinking Straight in the Age of Information Overload](https://en.wikipedia.org/wiki/Daniel_J._Levitin#Books) by Daniel J. Levitin
-- [Complexity: A Guided Tour](https://en.wikipedia.org/wiki/Complexity:_A_Guided_Tour) by Melanie Mitchell
-- [The Daily Stoic](https://en.wikipedia.org/wiki/Ryan_Holiday#Books) by Ryan Holiday and Stephen Hanselman
 - [Marc's Mission](https://en.wikipedia.org/wiki/Jocko_Willink#Books) by Jocko Willink
 - [Grit: The Power of Passion and Perseverance](https://en.wikipedia.org/wiki/Grit_(book)) by Angela Duckworth
 - [Pomodoro Technique Illustrated](https://en.wikipedia.org/wiki/Pomodoro_Technique) by Staffan Noteberg
-- [Ethics](https://en.wikipedia.org/wiki/Ethics_(Spinoza)) by Baruch Spinoza
 - [The Checklist Manifesto](https://en.wikipedia.org/wiki/The_Checklist_Manifesto) by Atul Gawande
-- [Lying](https://en.wikipedia.org/wiki/Sam_Harris#Writings) by Sam Harris
-- [The Drunkard's Walk: How Randomness Rules Our Lives](https://en.wikipedia.org/wiki/The_Drunkard%27s_Walk) by Leonard Mlodinow
+
+### Business
+- [Discover Your Inner Economist](https://en.wikipedia.org/wiki/Tyler_Cowen#Bibliography) by Tyler Cowen
+- [Zero to One: Notes on Startups, or How to Build the Future](https://en.wikipedia.org/wiki/Zero_to_One) by Peter Thiel and Blake Masters
+- [The Four Filters Invention of Warren Buffett and Charlie Munger](https://en.wikipedia.org/wiki/Warren_Buffett) by Bud Labitan
+- [Zone to Win](https://en.wikipedia.org/wiki/Geoffrey_Moore) by Geoffrey A. Moore
+
+### Culture
+- [Program or Be Programmed: Ten Commands for a Digital Age](https://en.wikipedia.org/wiki/Douglas_Rushkoff#Books) by Douglas Rushkoff
+- [What the Dog Saw](https://en.wikipedia.org/wiki/Malcolm_Gladwell) by Malcolm Gladwell
+- [Fooled by Randomness](https://en.wikipedia.org/wiki/Nassim_Nicholas_Taleb#Bibliography) by Nassim Nicholas Taleb
 - [The Pleasures and Sorrows of Work](https://en.wikipedia.org/wiki/Alain_de_Botton#Works) by Alain de Botton
+
+### Philosophy
+- [Man's Search for Meaning](https://en.wikipedia.org/wiki/Man%27s_Search_for_Meaning) by Viktor Frankl
+- [Meditations](https://en.wikipedia.org/wiki/Meditations) by Marcus Aurelius
+- [Homo Deus](https://en.wikipedia.org/wiki/Homo_Deus:_A_Brief_History_of_Tomorrow) by Yuval Noah Harari
+- [The Daily Stoic](https://en.wikipedia.org/wiki/Ryan_Holiday#Books) by Ryan Holiday and Stephen Hanselman
+- [Ethics](https://en.wikipedia.org/wiki/Ethics_(Spinoza)) by Baruch Spinoza
+- [Lying](https://en.wikipedia.org/wiki/Sam_Harris#Writings) by Sam Harris
+
+### Science
+- [Your Memory](https://en.wikipedia.org/wiki/Kenneth_L._Higbee) by Kenneth L. Higbee
+- [Complexity: A Guided Tour](https://en.wikipedia.org/wiki/Complexity:_A_Guided_Tour) by Melanie Mitchell
+- [The Drunkard's Walk: How Randomness Rules Our Lives](https://en.wikipedia.org/wiki/The_Drunkard%27s_Walk) by Leonard Mlodinow
+
+### Writing
+- [The Sense of Style](https://en.wikipedia.org/wiki/The_Sense_of_Style) by Steven Pinker
+- [Writing Tools](https://en.wikipedia.org/wiki/Roy_Peter_Clark) by Roy Peter Clark
+- [Bird by Bird: Some Instructions on Writing and Life](https://en.wikipedia.org/wiki/Bird_by_Bird) by Anne Lamott
+
+### Memoir
+- [What I Talk About When I Talk About Running](https://en.wikipedia.org/wiki/What_I_Talk_About_When_I_Talk_About_Running) by Haruki Murakami
+- [Surely You're Joking, Mr. Feynman!](https://en.wikipedia.org/wiki/Surely_You%27re_Joking,_Mr._Feynman!) by Richard Feynman and Ralph Leighton
+
+### History
+- [Napoleon: A Life](https://en.wikipedia.org/wiki/Andrew_Roberts_(historian)) by Andrew Roberts
+
+### Fiction
+- [Brave New World](https://en.wikipedia.org/wiki/Brave_New_World) by Aldous Huxley
 - [Understand](https://en.wikipedia.org/wiki/Ted_Chiang_bibliography#Short_fiction) by Ted Chiang
 
 ## Books that I would like to read one day
 
+### History
 - [Hagakure](https://en.wikipedia.org/wiki/Hagakure) by Yamamoto Tsunetomo
-- [Mirrorshades: The Cyberpunk Anthology](https://en.wikipedia.org/wiki/Mirrorshades) edited by Bruce Sterling
 
+### Fiction
+- [Mirrorshades: The Cyberpunk Anthology](https://en.wikipedia.org/wiki/Mirrorshades) edited by Bruce Sterling

--- a/content/books.md
+++ b/content/books.md
@@ -5,7 +5,7 @@ tags:
   - books
 ---
 
-This page tracks books I have finished and books that I would like to read someday.
+This page tracks books I have finished and others I hope to read someday, grouped by category for easier browsing.
 
 ## Finished
 


### PR DESCRIPTION
## Summary
- group finished books under category headings like `Self-help`, `Business`, and `Philosophy`
- group "Books that I would like to read one day" by category

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68481b935b0c832eaff8bf7871c28f3c